### PR TITLE
Fixing typo in react-js.md

### DIFF
--- a/how-to-guides/js-frameworks/react-js/react-js.md
+++ b/how-to-guides/js-frameworks/react-js/react-js.md
@@ -243,8 +243,7 @@ export default function ContactForm() {
         )}
       </div>
       <p
-        class="text-center text-sm
-      ">
+        className="text-center text-sm">
         <a
           href="https://web3forms.com/"
           target="_blank"


### PR DESCRIPTION
The original code on line 246 had "class" in a tag instead of "className"